### PR TITLE
feat: Add CORS configuration for localhost with wildcard port support

### DIFF
--- a/src/main/kotlin/training/goorm/portholemapapi/config/CorsConfig.kt
+++ b/src/main/kotlin/training/goorm/portholemapapi/config/CorsConfig.kt
@@ -1,0 +1,58 @@
+package training.goorm.portholemapapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfig(
+    private val environment: Environment
+) : WebMvcConfigurer {
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        val activeProfile = environment.activeProfiles.firstOrNull() ?: "dev"
+
+        registry.addMapping("/**")
+            .allowedOriginPatterns(*getAllowedOrigins(activeProfile).toTypedArray())
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600) // 1시간 캐시
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        val activeProfile = environment.activeProfiles.firstOrNull() ?: "dev"
+
+        configuration.allowedOriginPatterns = getAllowedOrigins(activeProfile)
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        configuration.maxAge = 3600L
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
+
+    private fun getAllowedOrigins(profile: String): List<String> {
+        return when (profile) {
+            "prod" -> listOf(
+                "https://yourdomain.com",
+                "https://www.yourdomain.com"
+            )
+            else -> listOf( // dev 및 기본값
+                "http://localhost*",
+                "https://localhost*",
+                "http://127.0.0.1*",
+                "https://127.0.0.1*"
+            )
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,20 @@ spring:
   mvc:
     servlet:
       path: /api
+  profiles:
+    active: dev
+
+# CORS 설정을 위한 사용자 정의 속성
+cors:
+  allowed-origins:
+    dev:
+      - "http://localhost*"
+      - "https://localhost*"
+      - "http://127.0.0.1*"
+      - "https://127.0.0.1*"
+    prod:
+      - "https://yourdomain.com"
+      - "https://www.yourdomain.com"
 
 management:
   server:
@@ -14,3 +28,26 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+---
+# 개발 환경 프로필
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+logging:
+  level:
+    training.goorm.portholemapapi: DEBUG
+
+---
+# 프로덕션 환경 프로필
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+logging:
+  level:
+    root: WARN
+    training.goorm.portholemapapi: INFO


### PR DESCRIPTION
- Add CorsConfig class with environment-based CORS policies
- Support http://localhost* and https://localhost* patterns for all ports
- Separate dev/prod environment configurations
- Enable credentials and configure proper headers
- Update application.yml with profile-specific settings